### PR TITLE
Convert avro schemas to prismatic style schemas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,11 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [prismatic/schema "0.2.6"]
+                 [prismatic/schema "0.4.4"]
                  [com.taoensso/tower "2.0.2"]
-
-                 ;; TODO: figure out how to put this in dev-dependencies
-                 [codox-md "0.2.0"]]
+                 [com.damballa/abracad "0.4.12"]]
   :plugins [[codox "0.6.7"]]
   :codox {:writer codox-md.writer/write-docs
           :output-dir "doc/v0.3.0"
@@ -16,5 +14,7 @@
 
 
   :profiles
-  {:test {:dependencies [[com.datomic/datomic-free "0.9.4899"]]}
-   :dev {:dependencies [[com.datomic/datomic-free "0.9.4899"]]}})
+  {:test {:dependencies [[com.datomic/datomic-free "0.9.4899"]]
+          :resource-paths ["test/resources"]}
+   :dev {:dependencies [[com.datomic/datomic-free "0.9.4899"]]
+         :resource-paths ["test/resources"]}})

--- a/src/integrity/avro.clj
+++ b/src/integrity/avro.clj
@@ -1,0 +1,48 @@
+(ns integrity.avro
+  "Generates a prismatic schema from an avro one"
+  (:require
+   [clojure.java.io :as io]
+   [schema.core :as s :refer [Bool Str]]
+   [abracad.avro :as avro])
+  (:import [org.apache.avro Schema$Type]))
+
+(def ByteArray (Class/forName "[B"))
+
+(defn ->map [avro-schema]
+  (condp = (.getType avro-schema)
+
+    ;; Primitive types
+    Schema$Type/BOOLEAN Bool
+    Schema$Type/INT     Integer
+    Schema$Type/LONG    Long
+    Schema$Type/FLOAT   Float
+    Schema$Type/DOUBLE  Double
+    Schema$Type/BYTES   ByteArray
+    Schema$Type/STRING  Str
+
+    ;; Complex Types
+    Schema$Type/RECORD
+    (apply hash-map (mapcat (fn [key val]
+                              [(keyword key) val])
+                            (map #(.name %) (.getFields avro-schema))
+                            (map #(->map (.schema %)) (.getFields avro-schema))))
+
+    Schema$Type/ENUM
+    (apply s/enum (.getEnumSymbols avro-schema))
+
+    Schema$Type/ARRAY
+    [(->map (.getElementType avro-schema))]
+
+    Schema$Type/MAP
+    {Str (->map (.getValueType avro-schema))}
+
+    Schema$Type/FIXED
+    (s/pred (fn [str-val]
+              (<= (.getFixedSize avro-schema) (count str-val)))
+            'exceeds-fixed-size)))
+
+(defn avro-errors [schema value]
+  (let [schema-as-map (->map schema)]
+    (s/check schema-as-map value)))
+
+

--- a/test/integrity/avro_test.clj
+++ b/test/integrity/avro_test.clj
@@ -1,0 +1,73 @@
+(ns integrity.avro-test
+  (:require
+   [abracad.avro :as avro]
+   [clojure.test :refer :all]
+   [clojure.java.io :as io]
+   [schema.core :as s :refer [Str Bool Num Int Inst Keyword]]
+   [integrity.avro :refer :all]
+   [integrity.test-helpers :refer [attr]])
+  (:import [java.util Date UUID]))
+
+(def test-schema (->map (avro/parse-schema
+                         (slurp (io/reader
+                                 (io/resource "avro-test-schema.json"))))))
+
+(defn- good? [attr values]
+  (not-any? #(attr (s/check test-schema %))
+            (map (partial hash-map attr) values)))
+
+(defn- bad? [attr values]
+  (every? #(attr (s/check test-schema %))
+          (map (partial hash-map attr) values)))
+
+(deftest test-primitive-types
+  (testing "boolean"
+    (is (good? :boolean [true false]))
+    (is (bad? :boolean [42 "42" {}])))
+
+  (testing "int"
+    (is (good? :int (map int [0 1 Integer/MAX_VALUE Integer/MIN_VALUE])))
+    (is (bad? :int [0.0 (+ Integer/MAX_VALUE 1)])))
+
+  (testing "long"
+    (is (good? :long (map long [0 1 Long/MAX_VALUE Long/MIN_VALUE])))
+    (is (bad? :long [(+ (bigdec Long/MAX_VALUE) 1)
+                     (- (bigdec Long/MIN_VALUE) 1)])))
+
+  (testing "float"
+    (is (good? :float (map float [3.14])))
+    (is (bad? :float (map int [3.14]))))
+
+  (testing "double"
+    (is (good? :double [3.14]))
+    (is (bad? :double (map int [3.14]))))
+
+  (testing "bytes"
+    (is (good? :bytes [(.getBytes "hello")]))
+    (is (bad? :bytes ["hello"])))
+
+  (testing "string"
+    (is (good? :string ["abc"]))
+    (is (bad? :string [42]))))
+
+(deftest test-complex-types
+  (testing "record"
+    (is (good? :record [{:a "a", :b "b"}]))
+    (is (bad? :record [{:a "missing b"}]))
+    (is (bad? :record ["not a record"])))
+
+  (testing "enum"
+    (is (good? :enum ["a" "b" "c"]))
+    (is (bad? :enum ["d"])))
+
+  (testing "array"
+    (is (good? :array [["first" "second"]]))
+    (is (bad? :array [[1 2]])))
+
+  (testing "map"
+    (is (good? :map [{"one" 1, "two" 2}]))
+    (is (bad? :map [{"one" 1.0, "two" 2.0}])))
+
+  (testing "fixed"
+    (is (good? :fixed ["1234123412341234"]))
+    (is (bad? :fixed ["1" "123412341234123"]))))

--- a/test/resources/avro-test-schema.json
+++ b/test/resources/avro-test-schema.json
@@ -1,0 +1,37 @@
+{
+  "namespace": "example.com",
+  "type": "record",
+  "name": "AvroTestSchema",
+  "fields": [
+    {"name": "boolean", "type": "boolean"},
+    {"name": "int", "type": "int"},
+    {"name": "long", "type": "long"},
+    {"name": "float", "type": "float"},
+    {"name": "double", "type": "double"},
+    {"name": "bytes", "type": "bytes"},
+    {"name": "string", "type": "string"},
+    {"name": "record", "type": {
+      "type": "record",
+      "name": "rec",
+      "fields": [
+        {"name": "a", "type": "string"},
+        {"name": "b", "type": "string"}
+      ]}},
+    {"name": "enum", "type": {
+      "type": "enum",
+      "name": "enum",
+      "symbols": ["a", "b", "c"]}},
+    {"name": "array", "type": {
+      "type": "array",
+      "name": "array",
+      "items": "string"}},
+    {"name": "map", "type": {
+      "type": "map",
+      "name": "map",
+      "values": "long"}},
+    {"name": "fixed", "type": {
+      "type": "fixed",
+      "name": "fixed",
+      "size": 16}}
+  ]
+}


### PR DESCRIPTION
Bring prismatic version up-to-date and add generator for avro schemas.

With this change, you can now get better error feedback on avro messages by converting the avro schema to a prismatic schema using the `integrity.avro/->map` function. The resulting map can be used anywhere a prismatic schema could be.

Resolves #12 